### PR TITLE
perf: fix rerender of unchanged tasks on the list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-list",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "description": "A simple todo list app built based on Atomic Design principles",
   "homepage": "https://ivanifj.github.io/todo-list/",

--- a/src/components/molecules/SideMenu/SideMenu.tsx
+++ b/src/components/molecules/SideMenu/SideMenu.tsx
@@ -2,12 +2,12 @@ import { X } from 'lucide-react'
 import styled from 'styled-components'
 import { useSideMenu } from '.'
 import { useOnKeyDown } from '../../../hooks/useOnKeyDown'
-import { useTaskList } from '../../../state'
 import { stores } from '../../../state/createStore'
 import { useChangeTheme } from '../../../styles'
 import { Typography } from '../../atoms/Typography'
 import { useEffect, useRef } from 'react'
 import { IconButton } from '../../atoms/IconButton'
+import { useTaskListActions } from '../../../state'
 
 const Container = styled.div<{ $opened: boolean }>`
   position: absolute;
@@ -74,7 +74,7 @@ function CloseSiteMenuButton() {
 
 export function SideMenu() {
   const { opened, close } = useSideMenu()
-  const { clearTasks } = useTaskList()
+  const { clearTasks } = useTaskListActions()
   const { changeTheme, current } = useChangeTheme()
   const ref = useRef<HTMLAnchorElement>(null)
 

--- a/src/components/molecules/Task.tsx
+++ b/src/components/molecules/Task.tsx
@@ -2,7 +2,7 @@ import { Pencil } from 'lucide-react/'
 import { memo, useCallback } from 'react'
 import styled from 'styled-components'
 import { TaskEntity } from '../../entities'
-import { useTaskList } from '../../state'
+import { useTaskListActions } from '../../state'
 import { formatDate } from '../../utils/formatDate'
 import { Checkbox } from '../atoms/Checkbox'
 import { IconButton } from '../atoms/IconButton'
@@ -60,10 +60,10 @@ const Content = styled.div`
 `
 
 function TaskCheckbox({ id, completed  }: {id: string, completed: boolean}) {
-  const toggle = useTaskList(({ toggleTask }) => toggleTask)
+  const { toggleTask } = useTaskListActions()
   const handleToggle = useCallback(() => {
-    toggle(id)
-  }, [id, toggle])
+    toggleTask(id)
+  }, [id, toggleTask])
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLOrSVGElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {

--- a/src/components/molecules/Task.tsx
+++ b/src/components/molecules/Task.tsx
@@ -1,16 +1,16 @@
+import { Pencil } from 'lucide-react/'
+import { memo, useCallback } from 'react'
 import styled from 'styled-components'
 import { TaskEntity } from '../../entities'
-import { Checkbox } from '../atoms/Checkbox'
-import { Typography } from '../atoms/Typography'
+import { useTaskList } from '../../state'
 import { formatDate } from '../../utils/formatDate'
-import { memo } from 'react'
-import { Pencil } from 'lucide-react/'
-import { useModal } from './Modal'
+import { Checkbox } from '../atoms/Checkbox'
 import { IconButton } from '../atoms/IconButton'
+import { Typography } from '../atoms/Typography'
+import { useModal } from './Modal'
 
 type TaskProps = {
   value: TaskEntity
-  onClick?: () => void
 }
 
 const Container = styled.div<{ $checked?: boolean }>`
@@ -59,20 +59,29 @@ const Content = styled.div`
   flex: 1;
 `
 
-export const Task = memo(function Task({ value, onClick }: TaskProps) {
+function TaskCheckbox({ id, completed  }: {id: string, completed: boolean}) {
+  const toggle = useTaskList(({ toggleTask }) => toggleTask)
+  const handleToggle = useCallback(() => {
+    toggle(id)
+  }, [id, toggle])
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLOrSVGElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleToggle()
+    }
+  }, [handleToggle])
+
+  return <Checkbox tabIndex={0} onClick={handleToggle} onKeyDown={handleKeyDown} $checked={completed} role="checkbox" aria-checked={completed} />
+}
+
+export const Task = memo(function Task({ value }: TaskProps) {
   const { completed, createdAt, name, id } = value
   const color = completed ? 'subtle' : 'base'
   const { open } = useModal()
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLOrSVGElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      onClick && onClick()
-    }
-  }
-
   return (
     <Container $checked={completed} role='listitem'>
-      <Checkbox tabIndex={0} onClick={onClick} onKeyDown={handleKeyDown} $checked={completed} role="checkbox" aria-checked={completed} />
+      <TaskCheckbox completed={completed} id={id} />
       <Content>
         <Name $color={color} $checked={completed} as="span" $variant='body'>{name}</Name>
         <Typography $color={color} $variant='caption2'>{formatDate(createdAt)}</Typography>

--- a/src/components/molecules/TaskForm.tsx
+++ b/src/components/molecules/TaskForm.tsx
@@ -2,10 +2,10 @@ import { PlusCircle, Save } from 'lucide-react'
 import { Button } from '../atoms/Button'
 import { Input } from '../atoms/Input'
 import { useEffect, useRef, useState } from 'react'
-import { taskListSelector, useTaskList } from '../../state'
 import styled from 'styled-components'
 import { useModal } from '../molecules/Modal'
 import { useOnKeyDown } from '../../hooks/useOnKeyDown'
+import { useTaskListActions } from '../../state'
 
 const Form = styled.form`
   display: flex;
@@ -16,7 +16,7 @@ const Form = styled.form`
 export function TaskForm() {
   const { payload, close } = useModal()
   const [name, setName] = useState(payload?.name || '')
-  const { createTask, editTask } = useTaskList(taskListSelector.actions)
+  const { createTask, editTask } = useTaskListActions()
   const ref = useRef<HTMLInputElement>(null)
   const label = payload ? 'Save' : 'Create task'
   const Icon = payload ? Save : PlusCircle

--- a/src/components/organism/Header.tsx
+++ b/src/components/organism/Header.tsx
@@ -10,13 +10,17 @@ const StyledHeader = styled.header`
   justify-content: space-between;
 `
 
-export function Header() {
+function SettingsButton() {
   const { open } = useSideMenu()
 
+  return <IconButton aria-label='Open settings' onClick={open} icon={Settings} />
+}
+
+export function Header() {
   return (
     <StyledHeader>
       <Typography as="h1" $variant='subheading' $color='subtle'>Atomic To-Do List</Typography>
-      <IconButton aria-label='Open settings' onClick={open} icon={Settings} />
+      <SettingsButton />
     </StyledHeader>
   )
 }

--- a/src/components/organism/TaskList/CompletedTaskList.tsx
+++ b/src/components/organism/TaskList/CompletedTaskList.tsx
@@ -1,17 +1,16 @@
+import { memo } from 'react'
 import styled from 'styled-components'
-import { taskListSelector, useTaskList } from '../../../state'
+import { useCompletedTasks, useTaskListActions } from '../../../state'
 import { Typography } from '../../atoms/Typography'
 import { Task } from '../../molecules/Task'
-import { memo } from 'react'
-import { useShallow } from 'zustand/react/shallow'
 
 const StyledTypography = styled(Typography)`
   margin: ${({ theme }) => `${theme.spacing(0.5)} 0`};
 `
 
 export const CompledTaskList = memo(function CompledTaskList() {
-  const { tasks } = useTaskList(useShallow(taskListSelector.completedTasks))
-  const { clearCompleted } = useTaskList(taskListSelector.actions)
+  const tasks = useCompletedTasks()
+  const { clearCompleted } = useTaskListActions()
 
   if (tasks.length === 0) return null
 

--- a/src/components/organism/TaskList/CompletedTaskList.tsx
+++ b/src/components/organism/TaskList/CompletedTaskList.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { taskListSelector, useTaskList } from '../../../state'
 import { Typography } from '../../atoms/Typography'
 import { Task } from '../../molecules/Task'
-
 import { memo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -12,7 +11,7 @@ const StyledTypography = styled(Typography)`
 
 export const CompledTaskList = memo(function CompledTaskList() {
   const { tasks } = useTaskList(useShallow(taskListSelector.completedTasks))
-  const { clearCompleted, toggleTask } = useTaskList(taskListSelector.actions)
+  const { clearCompleted } = useTaskList(taskListSelector.actions)
 
   if (tasks.length === 0) return null
 
@@ -31,7 +30,6 @@ export const CompledTaskList = memo(function CompledTaskList() {
         <Task
           key={task.id}
           value={task}
-          onClick={() => toggleTask(task.id)}
         />
       ))}
     </>

--- a/src/components/organism/TaskList/TaskList.tsx
+++ b/src/components/organism/TaskList/TaskList.tsx
@@ -24,13 +24,11 @@ const Container = styled.div`
 
 function List() {
   const { tasks } = useStoreWithEqualityFn(useTaskList, taskListSelector.pendingTasks, shallow)
-  const { toggleTask } = useTaskList(taskListSelector.actions)
  
   return (<>
     {tasks.map((task) => (
       <Task
         key={task.id}
-        onClick={() => toggleTask(task.id)}
         value={task}
       />
     ))}

--- a/src/components/organism/TaskList/TaskList.tsx
+++ b/src/components/organism/TaskList/TaskList.tsx
@@ -1,10 +1,8 @@
 import styled from 'styled-components'
-import { shallow } from 'zustand/shallow'
-import { useStoreWithEqualityFn } from 'zustand/traditional'
-import { taskListSelector, useTaskList } from '../../../state'
+import { usePendingTasks, useTaskListMeta } from '../../../state'
+import { Task } from '../../molecules/Task'
 import { CompledTaskList } from './CompletedTaskList'
 import { EmptyTaskList } from './EmptyTaskList'
-import { Task } from '../../molecules/Task'
 
 
 const Container = styled.div`
@@ -23,7 +21,7 @@ const Container = styled.div`
 `
 
 function List() {
-  const { tasks } = useStoreWithEqualityFn(useTaskList, taskListSelector.pendingTasks, shallow)
+  const tasks = usePendingTasks()
  
   return (<>
     {tasks.map((task) => (
@@ -36,7 +34,7 @@ function List() {
 }
 
 export function TaskList() {
-  const { total } = useTaskList(taskListSelector.meta)
+  const { total } = useTaskListMeta()
 
   if (total === 0) return <Container><EmptyTaskList /></Container>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,10 +5,10 @@ import { Modal, useModal } from '../components/molecules/Modal'
 import { TaskForm } from '../components/molecules/TaskForm'
 import { TaskList } from '../components/organism/TaskList'
 import { BaseLayout } from '../components/templates/BaseLayout'
-import { taskListSelector, useTaskList, useUser } from '../state'
+import { useTaskListMeta, useUser } from '../state'
 
 function TaskCounter() {
-  const { completed, total } = useTaskList(taskListSelector.meta)
+  const { completed, total } = useTaskListMeta()
   const emptyList = total === 0 
   const title = emptyList ? 'No tasks' : `All tasks ( ${total - completed} / ${total} )`
 

--- a/src/state/TaskList.ts
+++ b/src/state/TaskList.ts
@@ -1,3 +1,4 @@
+import { useShallow } from 'zustand/react/shallow'
 import { TaskEntity } from '../entities'
 import { generateId } from '../utils/generateId'
 import { createStore } from './createStore'
@@ -22,7 +23,7 @@ type TaskListStore = State & Actions
 
 const storeName = '@TaskList'
 
-export const useTaskList = createStore<TaskListStore>((set) => ({
+const useTaskList = createStore<TaskListStore>((set) => ({
   ...INITIAL_STATE,
   createTask: (name) => {
     set((state) => {
@@ -65,20 +66,12 @@ export const useTaskList = createStore<TaskListStore>((set) => ({
   }
 }), { name: storeName })
 
-const createTaskSelector = (kind: 'completed' | 'pending') => (state: TaskListStore) => ({
-  tasks: {
-    'completed': state.tasks.
-      filter(({ completed }) =>  completed).
-      sort((a, b) => (b.completedAt || 0) - (a.completedAt || 0)),
-    'pending': state.tasks.
-      filter(({ completed }) =>  !completed).
-      sort((a, b) => b.createdAt - a.createdAt)
-  }[kind],
-})
 
-export const taskListSelector = {
-  completedTasks: createTaskSelector('completed'),
-  pendingTasks: createTaskSelector('pending'),
+const selectors = {
+  pendingTasks: (store: TaskListStore ) => store.tasks.filter(({ completed }) =>  !completed).
+    sort((a, b) => b.createdAt - a.createdAt),
+  completedTasks: (store: TaskListStore ) => store.tasks.filter(({ completed }) => completed).
+    sort((a, b) => (b.completedAt || 0) - (a.completedAt || 0)),
   meta: ({ tasks }: TaskListStore) => ({
     total: tasks.length,
     completed: tasks.filter(({ completed }) => completed).length
@@ -86,3 +79,8 @@ export const taskListSelector = {
   actions: ({ clearCompleted, clearTasks, createTask, toggleTask, editTask }: TaskListStore) =>
     ({ clearCompleted, clearTasks, createTask, toggleTask, editTask })
 }
+
+export const useTaskListActions = () => useTaskList(useShallow(selectors.actions))
+export const useTaskListMeta = () => useTaskList(useShallow(selectors.meta))
+export const useCompletedTasks = () => useTaskList(useShallow(selectors.completedTasks))
+export const usePendingTasks = () => useTaskList(useShallow(selectors.pendingTasks))


### PR DESCRIPTION
## Enhance list performance

- Split components to isolate store access on [perf: fix rerender of unchanged tasks on the list](https://github.com/IvanIFJ/todo-list/pull/1/commits/6247b17302bb634f4aac39743160dc702937a19c)
- [reafactor: add custom store accessor hooks with shallow comparison](https://github.com/IvanIFJ/todo-list/pull/1/commits/33cd61812bf553972684426a070f53c7015a2fa1)
- [test: update store test](https://github.com/IvanIFJ/todo-list/pull/1/commits/5d4555be8ad4bf68d99475e32718f500a1df2dad)

### Before
Every item (task) on the list was beeing rerendered;
![Screen Shot 2024-02-06 at 11 48 21](https://github.com/IvanIFJ/todo-list/assets/9556242/3d1dcda3-39db-414b-ac1e-ac7a7328ccf0)
### After
Renrender triggered only where state changed
![Screen Shot 2024-02-06 at 11 49 42](https://github.com/IvanIFJ/todo-list/assets/9556242/defc0eaa-6add-476f-bfb5-0b92a65c863a)
